### PR TITLE
json 1.1 for spatial harvest try 2

### DIFF
--- a/ckanext/datajson/build_datajson.py
+++ b/ckanext/datajson/build_datajson.py
@@ -98,7 +98,7 @@ def make_datajson_entry(package,plugin):
             if not modified:
                 modified = referencedate[0]['value']
         if not modified:
-            modified =  clean_date(extra(package, "Last Update"))
+           modified =  clean_date(extra(package, "Last Update"))
         if not modified:
            modified =  clean_date(extra(package, "Metadata Date"))
         #log.warn("modified: %s",modified)
@@ -130,6 +130,8 @@ def make_datajson_entry(package,plugin):
         programCodePart =  extra(package,'Program Code')
         if not programCodePart:
            programCodePart =  program_code(harvest_object)
+        if not programCodePart:
+           programCodePart = "000:000"
         programCode = [ programCodePart  ]
         #
         # are these arrays in the ISO metadata? Should we be pulling them apart somehow?

--- a/ckanext/datajson/build_datajson.py
+++ b/ckanext/datajson/build_datajson.py
@@ -356,6 +356,7 @@ accrual_periodicity_spatial_dict = {
     'daily': 'R/P1D',
     'weekly': 'R/P1W',
     'fortnightly': 'R/P0.5M',
+    'annually': 'R/P1Y',
     'monthly': 'R/P1M',
     'quarterly': 'R/P3M',
     'biannualy': 'R/P0.5Y',
@@ -610,8 +611,9 @@ def extra(package, key, default=None):
                 #log.info("rolledup_extras key: %s, value: %s", k, value)
                 #new_extras.append({"key": k, "value": value})
                 new_extras[k] = value
-        #else:
+        else:
         #    new_extras.append(extra)
+             new_extras[extra['key']]=extra['value']
 
     #decode keys:
     for k, v in new_extras.iteritems():

--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -82,10 +82,17 @@ LANGUAGE_REGEX = re.compile(
 )
 
 # load the OMB bureau codes on first load of this module
-import urllib, csv
+import urllib, csv, StringIO
 
+
+#
+# AJS - sometimes we are getting back an M2Crypto that isn't iterable - not sure why
+#
 omb_burueau_codes = set()
-for row in csv.DictReader(urllib.urlopen("https://project-open-data.cio.gov/data/omb_bureau_codes.csv")):
+fp = urllib.urlopen("https://project-open-data.cio.gov/data/omb_bureau_codes.csv")
+csvstr = fp.read()
+for row in csv.DictReader(StringIO.StringIO(csvstr)):
+#for row in csv.DictReader(urllib.urlopen("https://project-open-data.cio.gov/data/omb_bureau_codes.csv")):
     omb_burueau_codes.add(row["Agency Code"] + ":" + row["Bureau Code"])
 
 # main function for validation

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -220,7 +220,7 @@ def make_json():
         # Create data.json only using public and public-restricted datasets, datasets marked non-public are not exposed
         for pkg in packages:
             total = total +1
-            extras = dict([(x['key'], x['value']) for x in pkg['extras']])
+            #extras = dict([(x['key'], x['value']) for x in pkg['extras']])
             try:
                 datajson_entry = make_datajson_entry(pkg,DataJsonPlugin)
                 if datajson_entry:
@@ -253,7 +253,7 @@ def make_jsonlines_file(tf):
         # Create data.json only using public and public-restricted datasets, datasets marked non-public are not exposed
         for pkg in packages:
             total = total +1
-            extras = dict([(x['key'], x['value']) for x in pkg['extras']])
+            #extras = dict([(x['key'], x['value']) for x in pkg['extras']])
             try:
                 datajson_entry = make_datajson_entry(pkg,DataJsonPlugin)
                 if datajson_entry:


### PR DESCRIPTION
This patch attempts to implement as much of the new crosswalk document as possible using the old crosswalk values. This should generate valid json 1.1 - although the json output will be improved once we update the spatial plugin with additional/modified xpaths to read from the ISO metadata. This patch may need a slight change after that work is done. I am not sure that this is the best way to determine to go down the spatial path:

date = extra(package, "Metadata Date")
if date:
...
else:

The second thing this patch does is to modify plugin.py to step through the database in 100 row increments.
params = {'limit': 100, 'page': 1}
packages = p.toolkit.get_action("current_package_list_with_resources")(None, params)

This should help reduce memory usage. Future improvements would be to do something different than spooling the output json into memory. The assumption right now is that the database record is bigger than the json output, and even if it was the same size, the memory consumption would be cut roughly in half.