### PR TITLE
Fixed: not all resource formats have mime types declared

### DIFF
--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from logging import getLogger
 
-from helpers import *
+from ckanext.datajson.helpers import *
 
 log = getLogger(__name__)
 
@@ -216,6 +216,15 @@ class Wrappers:
     full_field_map = None
     bureau_code_list = None
     resource_formats = None
+
+    @staticmethod
+    def ckan_url_for_dataset_id(id):
+        """Returns canonical URL to the provided dataset
+        """
+        import pylons.config as config
+        url = config.get('ckan.site_url') + '/dataset/' + id
+        return url
+
 
     @staticmethod
     def catalog_publisher(value):

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -90,7 +90,7 @@ class Package2Pod:
             Wrappers.full_field_map = json_fields
 
             for key, field_map in json_fields.iteritems():
-                # log.debug('%s => %s', key, field_map)
+                #log.debug('%s => %s', key, field_map)
 
                 field_type = field_map.get('type', 'direct')
                 is_extra = field_map.get('extra')
@@ -138,7 +138,7 @@ class Package2Pod:
                         if array_key:
                             dataset[key] = [Package2Pod.filter(t[array_key]) for t in package.get(field, {})]
                 if wrapper:
-                    # log.debug('wrapper: %s', wrapper)
+                    # log.debug('wrapper: %s => %s', wrapper, field_map)
                     method = getattr(Wrappers, wrapper)
                     if method:
                         Wrappers.current_field_map = field_map
@@ -490,12 +490,14 @@ class Wrappers:
     def mime_type_it(value):
         if not value:
             return value
-        formats = h.resource_formats()
+
+        formats      = h.resource_formats()
         format_clean = value.lower()
-        if format_clean in formats:
+
+        if format_clean in formats and formats[format_clean][0]:
             mime_type = formats[format_clean][0]
         else:
             mime_type = value
-        msg = value + ' ... BECOMES ... ' + mime_type
-        log.debug(msg)
+
+        log.debug('%s ... BECOMES ... %s', value, mime_type)
         return mime_type

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -220,10 +220,24 @@ class Wrappers:
     @staticmethod
     def ckan_url_for_dataset_id(id):
         """Returns canonical URL to the provided dataset
+
+        id -- The UUID for a CKAN dataset
+
+        Returns a URL string
         """
         import pylons.config as config
         url = config.get('ckan.site_url') + '/dataset/' + id
         return url
+
+    @staticmethod
+    def ckan_tags_to_keywords(tags):
+        """Converts core CKAN tags to a Keywords array
+
+        tags -- The tags dictionary from the CKAN package
+
+        Returns a list of keyword strings
+        """
+        return list(t['display_name'] for t in tags)
 
 
     @staticmethod


### PR DESCRIPTION
CKAN's resource format contains various formats with None for the mime type.  mime_type_id was not checking for this possibility and returning None for these file types, rather than returning the raw extension string.

Fixes #26 