### PR TITLE
Allow OMB Bureau codes to be read from local file. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,28 @@ Then restart your server and check out:
 	http://yourdomain.com/data.jsonld
 	   and
 	http://yourdomain.com/pod/validate	
-	
+
+Providing OMB Bureau Codes
+--------------------------
+
+The ```datajsonvalidator.py``` file needs a list of OMB agency 
+and bureau codes. With no configuration, this information is
+automatically pulled from the Project Open Data web site. However,
+you can provide a local file with the same information using the
+```CKAN_BUREAU_CSV_FILE``` environment variable. Alternatively,
+you can use the ```CKAN_BUREAU_CSV_URL``` environment variable to
+specify a different URL to fetch the information.
+
+By default, the URL is https://project-open-data.cio.gov/data/omb_bureau_codes.csv.
+
+An example csv file is provided named ```test_omb_bureau_codes.csv```. This
+file can be used by running the following command before starting
+this extension
+
+```
+export CKAN_BUREAU_CSV_FILE=test_omb_bureau_codes.csv
+```
+
 Caching The Response
 --------------------
 

--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -86,9 +86,17 @@ email_validator = lepl.apps.rfc3696.Email()
 # load the OMB bureau codes on first load of this module
 import urllib
 import csv
+import os
 
 omb_burueau_codes = set()
-for row in csv.DictReader(urllib.urlopen("https://project-open-data.cio.gov/data/omb_bureau_codes.csv")):
+if 'CKAN_BUREAU_CSV_FILE' in os.environ:
+  with open(os.environ['CKAN_BUREAU_CSV_FILE']) as csvfile:
+    reader = csv.DictReader(csvfile)
+    for row in reader:
+      omb_burueau_codes.add(row["Agency Code"] + ":" + row["Bureau Code"])
+else:
+  url = os.environ.get('CKAN_BUREAU_CSV_URL', 'https://project-open-data.cio.gov/data/omb_bureau_codes.csv')
+  for row in csv.DictReader(urllib.urlopen(url)):
     omb_burueau_codes.add(row["Agency Code"] + ":" + row["Bureau Code"])
 
 

--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -104,14 +104,14 @@ else:
 def do_validation(doc, errors_array, seen_identifiers):
     errs = {}
 
-    if type(doc) != list:
+    if type(doc) != dict:
         add_error(errs, 0, "Bad JSON Structure",
-                  "The file must be an array at its top level. "
-                  "That means the file starts with an open bracket [ and ends with a close bracket ].")
+                  "The file must be a dict at its top level. "
+                  "That means the file starts with an open brace { and ends with a close brace }.")
     elif len(doc) == 0:
         add_error(errs, 0, "Catalog Is Empty", "There are no entries in your file.")
     else:
-        for i, item in enumerate(doc):
+        for i, item in enumerate(doc['dataset']):
             # Required
 
             dataset_name = "dataset %d" % (i + 1)

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -377,7 +377,7 @@ class DataJsonController(BaseController):
 
             if body:
                 try:
-                    do_validation(body, c.errors)
+                    do_validation(body, c.errors, Package2Pod.seen_identifiers)
                 except Exception as e:
                     c.errors.append(("Internal Error", ["Something bad happened: " + unicode(e)]))
                 if len(c.errors) == 0:

--- a/test_omb_bureau_codes.csv
+++ b/test_omb_bureau_codes.csv
@@ -1,0 +1,3 @@
+Agency Name,Bureau Name,Agency Code,Bureau Code,Treasury Code,CGAC Code
+TEST-Legislative Branch,Senate,001,05,00,000
+TEST-Judicial Branch,Supreme Court of the United States,002,05,10,010


### PR DESCRIPTION
Refer to GSA/ckanext-datajson/issues/32 for details. I did not know how to add error handling but the original code didn't handle errors so I hope this is OK. I added a section to the README to explain how the code works.
