### PR TITLE
FIX entry point for DataJsonHarvester in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         """
         [ckan.plugins]
         datajson=ckanext.datajson.plugin:DataJsonPlugin
-        datajson_harvest=ckanext.datajson.plugin:DataJsonHarvester
+        datajson_harvest=ckanext.datajson.harvester_datajson:DataJsonHarvester
         cmsdatanav_harvest=ckanext.datajson.plugin:CmsDataNavigatorHarvester
         """,
 )


### PR DESCRIPTION
See https://lists.okfn.org/pipermail/ckan-dev/2017-February/010805.html

Up for discussion here but found in CKAN 2.6.x the harvester cause errors after installation.
Discussion on dev list (see above) turned up a small issue which when changed locally fixed the problem.

 Is there the same issue with `datajson=ckanext.datajson.plugin:DataJsonPlugin` and `cmsdatanav_harvest=ckanext.datajson.plugin:CmsDataNavigatorHarvester` also? 