### PR TITLE
Update contributing and license.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Placeholder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 ## Welcome!
 
-We're so glad you're thinking about contributing to Data.gov!
+We're so glad you're thinking about contributing to ckanext-datajson!
 
 Before contributing, we encourage you to read our CONTRIBUTING guide (you are here), our [LICENSE](LICENSE.md), and our [README](README.md), all of which should be in this repository. If you have any questions, you can email the Data.gov team at [datagov@gsa.gov](mailto:datagov@gsa.gov).
 
 ## Ways to Contribute
 
-**The Data.gov team manages all Data.gov updates, bugs, and feature additions via GitHub's public [issue tracker](/issues) in this repository.** 
+**The Data.gov team manages all Data.gov updates, bugs, and feature additions via GitHub's public [issue tracker](https://github.com/GSA/ckanext-datajson/issues) in this repository.** 
 
 If you do not already have a GitHub account, you can [sign up for GitHub here](https://github.com/). In the spirit of open source software, everyone is encouraged to help improve this project. Here are some ways you can contribute:
 - by reporting bugs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,34 @@
-Placeholder
+## Welcome!
+
+We're so glad you're thinking about contributing to Data.gov!
+
+Before contributing, we encourage you to read our CONTRIBUTING guide (you are here), our [LICENSE](LICENSE.md), and our [README](README.md), all of which should be in this repository. If you have any questions, you can email the Data.gov team at [datagov@gsa.gov](mailto:datagov@gsa.gov).
+
+## Ways to Contribute
+
+**The Data.gov team manages all Data.gov updates, bugs, and feature additions via GitHub's public [issue tracker](/issues) in this repository.** 
+
+If you do not already have a GitHub account, you can [sign up for GitHub here](https://github.com/). In the spirit of open source software, everyone is encouraged to help improve this project. Here are some ways you can contribute:
+- by reporting bugs
+- by suggesting new features
+- by translating content to a new language
+- by writing or editing documentation
+- by writing specifications
+- by writing code and documentation (**no pull request is too small**: fix typos, add code comments, clean up inconsistent whitespace)
+- by reviewing [pull requests](https://github.com/GSA/ckanext-datajson/pulls).
+- by closing issues
+
+#### Submit Great Issues
+* Before submitting a new [issue](https://github.com/GSA/ckanext-datajson/issues), check to make sure [a similar issue isn't already open](https://github.com/GSA/ckanext-datajson/issues?q=is%3Aissue+is%3Aopen). If one is, contribute to that issue thread with your feedback.
+* When submitting a bug report, please try to provide as much detail as possible, i.e. a screenshot or [gist](https://gist.github.com/) that demonstrates the problem, the technology you are using, and any relevant links. 
+
+#### Ready for your Help 
+Issues labeled :sparkles:[`help wanted`](https://github.com/GSA/ckanext-datajson/labels/help%20wanted):sparkles: make it easy for you to find ways you can contribute today. 
+
+## Public Domain
+
+This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+## Public Domain
+
+This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest. See [CONTRIBUTING](CONTRIBUTING.md) for more information. 
+
+## GNU General Public License
+
+This project utilizes code [licensed under the terms of the GNU General Public License](https://wordpress.org/about/gpl/) and therefore is licensed under GPL v2 or later.
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+Visit http://www.gnu.org/licenses/ to learn more about the GNU General Public License.
+
+## Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.

--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ public domain dedication (which can be found at http://creativecommons.org/publi
 ## Ways to Contribute
 We're so glad you're thinking about contributing to ckanext-datajson!
 
-Before contributing to Data.gov we encourage you to read our [CONTRIBUTING](CONTRIBUTING.md) guide, our [LICENSE](LICENSE.md), and our README (you are here), all of which should be in this repository. If you have any questions, you can email the Data.gov team at [datagov@gsa.gov](mailto:datagov@gsa.gov).
+Before contributing to ckanext-datajson we encourage you to read our [CONTRIBUTING](CONTRIBUTING.md) guide, our [LICENSE](LICENSE.md), and our README (you are here), all of which should be in this repository. If you have any questions, you can email the Data.gov team at [datagov@gsa.gov](mailto:datagov@gsa.gov).

--- a/README.md
+++ b/README.md
@@ -170,3 +170,8 @@ As a work of the United States Government, this package is in the public
 domain within the United States. Additionally, we waive copyright and 
 related rights in the work worldwide through the CC0 1.0 Universal 
 public domain dedication (which can be found at http://creativecommons.org/publicdomain/zero/1.0/).
+
+## Ways to Contribute
+We're so glad you're thinking about contributing to ckanext-datajson!
+
+Before contributing to Data.gov we encourage you to read our [CONTRIBUTING](CONTRIBUTING.md) guide, our [LICENSE](LICENSE.md), and our README (you are here), all of which should be in this repository. If you have any questions, you can email the Data.gov team at [datagov@gsa.gov](mailto:datagov@gsa.gov).


### PR DESCRIPTION
Added CONTRIBUTING.md and LICENSE.md in accordance with this issue https://github.com/GSA/data.gov/issues/490

I made some assumptions on the emailing data.gov team and renaming the "We're so glad you're thinking about contributing to _ckanext-datajson_" from _Data.gov_

If you prefer it to remain Data.gov or want the email reference removed let me know.