### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ckanext-datajson
 A CKAN extension containinig plugins ``datajson``.
 First is used by http://catalog.data.gov/ to harvest data sources 
 from a remote /data.json file according to the U.S. Project
-Open Data metadata specification (https://project-open-data.cio.gov/).
+Open Data metadata specification (https://resources.data.gov/schemas/dcat-us/v1.1/).
 
 Plugin ``datajson`` provides a harvester to import datasets from other
 remote /data.json files. See below for setup instructions.

--- a/ckanext/datajson/build_datajson.py
+++ b/ckanext/datajson/build_datajson.py
@@ -242,7 +242,7 @@
 #     # 'extrasRollup', 'format', 'accessURL', 'notes', 'publisher_1', 'publisher_2', 'publisher_3',
 #     # 'publisher_4', 'publisher_5']
 #     #
-#     # # Append any free extras (key/value pairs) that aren't part of common core but have been associated with the dataset
+#     # # Append any free extras (key/value pairs) that aren't part of DCAT-US but have been associated with the dataset
 #     # # TODO really hackey, short on time, had to hardcode a lot of the names to remove. there's much better ways, maybe
 #     # # generate a list of keys to ignore by calling a specific function to get the extras
 #     # retlist_keys = [x for x, y in retlist]

--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -89,7 +89,7 @@ import csv
 import os
 
 omb_burueau_codes = set()
-# for row in csv.DictReader(urllib.urlopen("https://project-open-data.cio.gov/data/omb_bureau_codes.csv")):
+# for row in csv.DictReader(urllib.urlopen("https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv")):
 #    omb_burueau_codes.add(row["Agency Code"] + ":" + row["Bureau Code"])
 
 with open(os.path.join(os.path.dirname(__file__), "resources", "omb_bureau_codes.csv"), "r") as csvfile:
@@ -139,7 +139,7 @@ def do_validation(doc, errors_array, seen_identifiers):
                         elif bc not in omb_burueau_codes:
                             add_error(errs, 5, "Invalid Required Field Value",
                                       "The bureau code \"%s\" was not found in our list "
-                                      "(https://project-open-data.cio.gov/data/omb_bureau_codes.csv)." % bc,
+                                      "(https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv)." % bc,
                                       dataset_name)
 
             # contactPoint # required

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -301,7 +301,7 @@ class DataJsonController(BaseController):
 
     def is_valid(self, instance):
         """
-        Validates a data.json entry against the project open data's JSON schema.
+        Validates a data.json entry against the DCAT_US JSON schema.
         Log a warning message on validation error
         """
         error = best_match(draft4validator.iter_errors(instance))

--- a/ckanext/datajson/templates/datajsonvalidator.html
+++ b/ckanext/datajson/templates/datajsonvalidator.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}Validate a Project Open Data /data.json File{% endblock %}
+{% block subtitle %}Validate a DCAT-US /data.json File{% endblock %}
 
 {% block breadcrumb_content %}
 {% endblock %}
@@ -8,9 +8,9 @@
 {% block primary %}
   <article class="module">
     <div class="module-content">
-      <h1>Validate a Project Open Data /data.json File</h1>
+      <h1>Validate a DCAT-US /data.json File</h1>
       
-      <p>Let&rsquo;s validate that a data.json file meets the <a href="https://resources.data.gov/schemas/dcat-us/v1.1/">Project Open Data Metadata Schema</a>.</p>
+      <p>Let&rsquo;s validate that a data.json file meets the <a href="https://resources.data.gov/schemas/dcat-us/v1.1/">DCAT-US Metadata Schema</a>.</p>
 	
       <form method="post">
       	<label for="validate_url">Address of data.json file</label>

--- a/ckanext/datajson/templates/datajsonvalidator.html
+++ b/ckanext/datajson/templates/datajsonvalidator.html
@@ -10,7 +10,7 @@
     <div class="module-content">
       <h1>Validate a Project Open Data /data.json File</h1>
       
-      <p>Let&rsquo;s validate that a data.json file meets the <a href="http://project-open-data.github.io/schema/">Project Open Data Metadata Schema</a>.</p>
+      <p>Let&rsquo;s validate that a data.json file meets the <a href="https://resources.data.gov/schemas/dcat-us/v1.1/">Project Open Data Metadata Schema</a>.</p>
 	
       <form method="post">
       	<label for="validate_url">Address of data.json file</label>

--- a/ckanext/datajson/templates/html_rendition.html
+++ b/ckanext/datajson/templates/html_rendition.html
@@ -14,7 +14,7 @@
 
       <ul>
         <li>Use the <a href='/dataset'>Dataset Search &amp; Browse Page</a> to search datasets or browse and filter by publisher or subject.</li>
-        <li>Download the complete data catalog in our <a href="/data.json">data.json</a> or <a href="/data.jsonld">data.jsonld</a> file, which uses the <a href="https://resources.data.gov/schemas/dcat-us/v1.1/">Project Open Data Metadata Schema</a>.</li>
+        <li>Download the complete data catalog in our <a href="/data.json">data.json</a> or <a href="/data.jsonld">data.jsonld</a> file, which uses the <a href="https://resources.data.gov/schemas/dcat-us/v1.1/">DCAT-US Metadata Schema</a>.</li>
         <li>Scroll down to see a list of datasets in the catalog with the most recently updated datesets listed first.</li>
       </ul>
 

--- a/ckanext/datajson/templates/html_rendition.html
+++ b/ckanext/datajson/templates/html_rendition.html
@@ -14,7 +14,7 @@
 
       <ul>
         <li>Use the <a href='/dataset'>Dataset Search &amp; Browse Page</a> to search datasets or browse and filter by publisher or subject.</li>
-        <li>Download the complete data catalog in our <a href="/data.json">data.json</a> or <a href="/data.jsonld">data.jsonld</a> file, which uses the <a href="http://project-open-data.github.io/schema/">Project Open Data Metadata Schema</a>.</li>
+        <li>Download the complete data catalog in our <a href="/data.json">data.json</a> or <a href="/data.jsonld">data.jsonld</a> file, which uses the <a href="https://resources.data.gov/schemas/dcat-us/v1.1/">Project Open Data Metadata Schema</a>.</li>
         <li>Scroll down to see a list of datasets in the catalog with the most recently updated datesets listed first.</li>
       </ul>
 


### PR DESCRIPTION
Documentation updates per #[1071](https://github.com/GSA/datagov-deploy/issues/1071)

Could use clarification if the standard will continue to be named the "Project Open Data Standard", as mentioned [here](https://github.com/GSA/ckanext-datajson/compare/master...GSA:feature/resources.data.gov_move?expand=1#diff-379ce61984db923f809bc38219726d4b)