### PR TITLE
replace all references and skip errors

### DIFF
--- a/ckanext/datajson/export_map/export.catalog.map.sample.json
+++ b/ckanext/datajson/export_map/export.catalog.map.sample.json
@@ -1,9 +1,9 @@
 {
   "validation_enabled": false,
   "catalog_headers": {
-    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+    "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+    "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
     "@type": "dcat:Catalog"
   },
   "dataset_fields_map": {

--- a/ckanext/datajson/export_map/export.inventory.map.sample.json
+++ b/ckanext/datajson/export_map/export.inventory.map.sample.json
@@ -2,9 +2,9 @@
   "validation_enabled": true,
   "debug": false,
   "catalog_headers": {
-    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+    "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+    "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
     "@type": "dcat:Catalog"
   },
   "dataset_fields_map": {

--- a/ckanext/datajson/export_map/export.spatial.map.sample.json
+++ b/ckanext/datajson/export_map/export.spatial.map.sample.json
@@ -1,9 +1,9 @@
 {
   "validation_enabled": true,
   "catalog_headers": {
-    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+    "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+    "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
     "@type": "dcat:Catalog"
   },
   "dataset_fields_map": {

--- a/ckanext/datajson/harvester_datajson.py
+++ b/ckanext/datajson/harvester_datajson.py
@@ -50,6 +50,16 @@ class DataJsonHarvester(DatasetHarvesterBase):
             catalog_values = datasets.copy()
             datasets = catalog_values.pop("dataset", [])
 
+            # hotfix to deal with an unexpected domain redirection
+            for k, v in catalog_values.items():
+                catalog_values[k] = v.replace("https://project-open-data.cio.gov/v1.1/schema", "https://resources.data.gov/schemas/dcat-us/v1.1/schema")
+    
+        for dataset in datasets:
+            if dataset.get("license") == "https://project-open-data.cio.gov/unknown-license":
+                dataset["license"] = "https://github.com/project-open-data/project-open-data.github.io/blob/master/unknown-license.md"
+            elif dataset.get("license") == "https://project-open-data.cio.gov/open-licenses":
+                dataset["license"] = "https://resources.data.gov/open-licenses/"
+        
         return (datasets, catalog_values)
         
     def set_dataset_info(self, pkg, dataset, dataset_defaults, schema_version):

--- a/ckanext/datajson/pod_schema/federal-v1.1/catalog.json
+++ b/ckanext/datajson/pod_schema/federal-v1.1/catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://project-open-data.cio.gov/v1.1/schema/catalog.json#",
+  "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json#",
   "title": "Project Open Data Catalog",
   "description": "Validates an entire collection of common core metadata JSON objects. Agencies produce said collections in the form of Data.json files.",
   "type": "object",
@@ -37,7 +37,7 @@
       "description": "Version of Schema",
       "title": "Version of Schema",
       "enum": [
-        "https://project-open-data.cio.gov/v1.1/schema"
+        "https://resources.data.gov/schemas/dcat-us/v1.1/schema"
       ]
     },
     "describedBy": {

--- a/ckanext/datajson/pod_schema/federal-v1.1/dataset.json
+++ b/ckanext/datajson/pod_schema/federal-v1.1/dataset.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://project-open-data.cio.gov/v1.1/schema/dataset.json#",
+  "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/dataset.json#",
   "title": "Project Open Data Dataset",
   "description": "The metadata format for all federal open data. Validates a single JSON object entry (as opposed to entire Data.json catalog).",
   "type": "object",
@@ -475,7 +475,7 @@
   "definitions": {
     "vcard": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
+      "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/vcard.json#",
       "title": "Project Open Data ContactPoint vCard",
       "description": "A Dataset ContactPoint as a vCard object",
       "type": "object",
@@ -515,7 +515,7 @@
     },
     "distribution": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/distribution.json#",
+      "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/distribution.json#",
       "title": "Project Open Data Distribution",
       "description": "Validates an entire collection of common core metadata JSON objects. Agencies produce said collections in the form of Data.json files.",
       "type": "object",
@@ -698,7 +698,7 @@
     },
     "organization": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/organization.json#",
       "title": "Project Open Data Organization",
       "description": "A Dataset Publisher Organization as a foaf:Agent object",
       "type": "object",

--- a/ckanext/datajson/pod_schema/non-federal-v1.1/catalog.json
+++ b/ckanext/datajson/pod_schema/non-federal-v1.1/catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://project-open-data.cio.gov/v1.1/schema/catalog.json#",
+  "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json#",
   "title": "Project Open Data Catalog",
   "description": "Validates an entire collection of common core metadata JSON objects. Agencies produce said collections in the form of Data.json files.",
   "type": "object",
@@ -37,7 +37,7 @@
       "description": "Version of Schema",
       "title": "Version of Schema",
       "enum": [
-        "https://project-open-data.cio.gov/v1.1/schema"
+        "https://resources.data.gov/schemas/dcat-us/v1.1/schema"
       ]
     },
     "describedBy": {

--- a/ckanext/datajson/pod_schema/non-federal-v1.1/dataset-non-federal.json
+++ b/ckanext/datajson/pod_schema/non-federal-v1.1/dataset-non-federal.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://project-open-data.cio.gov/v1.1/schema/dataset-non-federal.json#",
+  "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/dataset-non-federal.json#",
   "title": "Project Open Data Dataset",
   "description": "The metadata format for all federal open data. Validates a single JSON object entry (as opposed to entire Data.json catalog).",
   "type": "object",
@@ -368,7 +368,7 @@
   "definitions": {
     "vcard-non-federal": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/vcard-non-federal.json#",
+      "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/vcard-non-federal.json#",
       "title": "Project Open Data ContactPoint vCard",
       "description": "A Dataset ContactPoint as a vCard object",
       "type": "object",
@@ -399,7 +399,7 @@
     },
     "distribution": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/distribution.json#",
+      "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/distribution.json#",
       "title": "Project Open Data Distribution",
       "description": "Validates an entire collection of common core metadata JSON objects. Agencies produce said collections in the form of Data.json files.",
       "type": "object",
@@ -538,7 +538,7 @@
     },
     "organization": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "id": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/organization.json#",
       "title": "Project Open Data Organization",
       "description": "A Dataset Publisher Organization as a foaf:Agent object",
       "type": "object",

--- a/ckanext/datajson/tests/datajson-samples/arm.data.json
+++ b/ckanext/datajson/tests/datajson-samples/arm.data.json
@@ -1,7 +1,7 @@
 {
-  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+  "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+  "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
   "@type": "dcat:Catalog",
   "dataset": [
     {

--- a/ckanext/datajson/tests/datajson-samples/large-spatial.data.json
+++ b/ckanext/datajson/tests/datajson-samples/large-spatial.data.json
@@ -1,8 +1,8 @@
 {
   "@type": "dcat:Catalog",
-  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+  "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+  "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
   "dataset": [
     {
       "identifier": "bad-02",

--- a/ckanext/datajson/tests/datajson-samples/null-spatial.data.json
+++ b/ckanext/datajson/tests/datajson-samples/null-spatial.data.json
@@ -1,8 +1,8 @@
 {
   "@type": "dcat:Catalog",
-  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+  "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+  "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
   "dataset": [
     {
       "identifier": "null-spatial",

--- a/ckanext/datajson/tests/datajson-samples/reserved-title.data.json
+++ b/ckanext/datajson/tests/datajson-samples/reserved-title.data.json
@@ -1,8 +1,8 @@
 {
   "@type": "dcat:Catalog",
-  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
-  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "describedBy": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.json",
+  "conformsTo": "https://resources.data.gov/schemas/dcat-us/v1.1/schema",
+  "@context": "https://resources.data.gov/schemas/dcat-us/v1.1/schema/catalog.jsonld",
   "dataset": [
     {
       "identifier": "bad-01",


### PR DESCRIPTION
Related to [datagov-deploy#1895](https://github.com/GSA/datagov-deploy/issues/1895)

This PR:
 - Replace all references to the new domain
 - Temporarily skip the error related whit this change

