### PR TITLE
Catch exception when a json source returns a HTTPError

### DIFF
--- a/ckanext/datajson/harvester_datajson.py
+++ b/ckanext/datajson/harvester_datajson.py
@@ -30,6 +30,9 @@ class DataJsonHarvester(DatasetHarvesterBase):
                 datasets = json.load(urllib2.urlopen(req), 'cp1252')
             except:
                 datasets = json.load(urllib2.urlopen(req), 'iso-8859-1')
+        except urllib2.HTTPError as e:
+            self._save_gather_error("Error getting json source: %s." % (e), harvest_job)
+            return []
         except:
             # remove BOM
             datasets = json.loads(lstrip_bom(urllib2.urlopen(req).read()))

--- a/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
+++ b/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
@@ -138,7 +138,7 @@ class TestDataJSONHarvester(object):
         assert_in(munge_title_to_name("Congressional Logs"), tags)
 
     def test_source_returning_http_error(self):
-        url = 'http://www.cpsc.gov/data.json'
+        url = 'http://127.0.0.1:%s/404' % self.mock_port
         self.run_source(url)
 
         assert_raises(HTTPError)


### PR DESCRIPTION
Catch exception when a json source returns an httperror and put the error in the harvest log