### PR TITLE
Fix responses to test charsets

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -38,8 +38,8 @@ echo "Installing Python dependencies..."
 
 pip install wheel
 
-# https://github.com/GSA/ckanext-datajson/issues/61
-pip install setuptools~=45.0
+pip install --upgrade pip
+pip install setuptools -U
 
 python setup.py develop
 cp ./ckan/public/base/css/main.css ./ckan/public/base/css/main.debug.css

--- a/ckanext/datajson/harvester_datajson.py
+++ b/ckanext/datajson/harvester_datajson.py
@@ -31,17 +31,18 @@ class DataJsonHarvester(DatasetHarvesterBase):
             self._save_gather_error("URL Error getting json source: %s." % (e), harvest_job)
             return []
 
+        data = response.read()
         try:
-            datasets = json.load(response)
+            datasets = json.loads(data)
         except UnicodeDecodeError:
             # try different encode
             try:
-                datasets = json.load(response, 'cp1252')
+                datasets = json.loads(data, 'cp1252')
             except:
-                datasets = json.load(response, 'iso-8859-1')
+                datasets = json.loads(data, 'iso-8859-1')
         except:
             # remove BOM
-            datasets = json.loads(lstrip_bom(urllib2.urlopen(req).read()))
+            datasets = json.loads(lstrip_bom(data))
 
         # The first dataset should be for the data.json file itself. Check that
         # it is, and if so rewrite the dataset's title because Socrata exports

--- a/ckanext/datajson/tests/test_collections_ui.py
+++ b/ckanext/datajson/tests/test_collections_ui.py
@@ -65,9 +65,11 @@ class TestCollectionUI(helpers.FunctionalTestBase):
                 url = '/dataset/{}'.format(parent_name)
                 log.info('Goto URL {}'.format(url))
                 res = self.app.get(url)
-                expected_link = '<a href="/dataset?collection_package_id={}" class="btn">Search datasets within this collection</a>'.format(collection_package_id)
+                expected_link = '<a href="/dataset?collection_package_id={}"'.format(collection_package_id)
                 assert_in(expected_link, res.unicode_body)
-
+                expected_text = 'Search datasets within this collection'
+                assert_in(expected_text, res.unicode_body)
+                
                 # show children
                 url = '/dataset?collection_package_id={}'.format(collection_package_id)
                 log.info('Goto URL {}'.format(url))


### PR DESCRIPTION
Related to [Multi#416](https://github.com/GSA/datagov-ckan-multi/issues/416)

Response object requires to be read just one time.