### PR TITLE
The config is not included in harvest_source_show

### DIFF
--- a/ckanext/datajson/datajson_ckan_28.py
+++ b/ckanext/datajson/datajson_ckan_28.py
@@ -63,6 +63,8 @@ class DatasetHarvesterBase(HarvesterBase):
             "defaults": {}, # map field name to value to supply as default if none exists, handled by the actual importer module, so the field names may be arbitrary
         }
 
+        if harvest_source.config is None or harvest_source.config == '':
+            harvest_source.config = '{}'
         source_config = json.loads(harvest_source.config)
         log.debug('SOURCE CONFIG {}'.format(source_config))
         ret.update(source_config)

--- a/ckanext/datajson/datajson_ckan_28.py
+++ b/ckanext/datajson/datajson_ckan_28.py
@@ -9,7 +9,7 @@ from ckan.lib.navl.dictization_functions import Invalid, DataError
 from ckan.lib.navl.validators import ignore_empty
 
 from ckanext.harvest.model import HarvestJob, HarvestObject, HarvestGatherError, \
-                                    HarvestObjectError, HarvestObjectExtra
+                                    HarvestObjectError, HarvestObjectExtra, HarvestSource
 from ckanext.harvest.harvesters.base import HarvesterBase
 from ckanext.datajson.exceptions import ParentNotHarvestedException
 import uuid, datetime, hashlib, urllib2, json, yaml, json, os
@@ -63,9 +63,7 @@ class DatasetHarvesterBase(HarvesterBase):
             "defaults": {}, # map field name to value to supply as default if none exists, handled by the actual importer module, so the field names may be arbitrary
         }
 
-        search_dict = {'id': harvest_source.id}
-        source_dict = p.toolkit.get_action('harvest_source_show')({}, search_dict)
-        source_config = json.loads(source_dict.get('config', '{}'))
+        source_config = json.loads(harvest_source.config)
         log.debug('SOURCE CONFIG {}'.format(source_config))
         ret.update(source_config)
 


### PR DESCRIPTION
Fix how we load the harvest source configuration
We now are missing `validation_schema` (e.g. to use non-federal sources) and all config values

This is probably related to how we handle `harvest_source_show` function in our fork: https://github.com/GSA/ckanext-harvest/blob/datagov/ckanext/harvest/logic/action/get.py#L58