### PR TITLE
Deprecate duplicate creation

### DIFF
--- a/ckanext/datajson/datajson_ckan_28.py
+++ b/ckanext/datajson/datajson_ckan_28.py
@@ -729,9 +729,7 @@ class DatasetHarvesterBase(HarvesterBase):
                 # sometimes one fetch worker does not see new pkg added
                 # by other workers. it gives db error for pkg with same title.
                 model.Session.rollback()
-                pkg['name'] = self.make_package_name(dataset_processed["title"], harvest_object.guid)
-                pkg = get_action('package_create')(self.context(), pkg)
-                log.warn('created package %s (%s) from %s' % (pkg["name"], pkg["id"], harvest_object.source.url))
+                log.warn('package already created %s (%s) from %s' % (pkg["name"], pkg["id"], harvest_object.source.url))
             except Exception as e:
                 log.error('Failed to create package %s from %s\n\t%s\n\t%s' % (pkg["name"], harvest_object.source.url, unicode(pkg), unicode(e)))
                 raise


### PR DESCRIPTION
When catching an error with a package create, log and move on: do not attempt re-creation.
Related to https://github.com/GSA/datagov-deploy/issues/2981.