### PR TITLE
Add index for each package creation

### DIFF
--- a/ckanext/datajson/datajson_ckan_28.py
+++ b/ckanext/datajson/datajson_ckan_28.py
@@ -10,6 +10,7 @@ from ckan.logic.validators import name_validator
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.navl.dictization_functions import Invalid, DataError
 from ckan.lib.navl.validators import ignore_empty
+from ckan.lib.search import rebuild
 
 from ckanext.harvest.model import HarvestObject, HarvestObjectError, HarvestObjectExtra
 from ckanext.harvest.harvesters.base import HarvesterBase
@@ -769,9 +770,7 @@ class DatasetHarvesterBase(HarvesterBase):
         # does this by creating the association before the package is saved by
         # overriding the GUID creation on a new package. That's too difficult.
         # So here we end up indexing twice.
-        # !!! DISABLED - causes showing wrong number of datasets, when you try to
-        # !!! list datasets by harvest source /harvest/{source_id}
-        # PackageSearchIndex().index_package(pkg)
+        rebuild(pkg['id'])
 
         return True
 


### PR DESCRIPTION
You will see that re-indexing was commented out. Not sure where the "different" count problem has arisen from, but multiple tests of re-harvesting caused no issues (both keeping the data same, and changing the modified date to force a re-harvest).

I wonder if this was some confusion around collections; we have had many requests around why the number of datasets harvested doesn't match the number of resulting datasets. This is due to the fact that the harvest system doesn't know the difference between parent level and child level datasets. So if there are 6 datasets in a data.json file, 3 of which are actually children of another dataset, then the harvest system will report 6 datasets added but also that there are only 3 datasets associated with the harvest source. This is actually the expected behavior currently, just confusing.