### PR TITLE
new: update jquery to the correct filename

### DIFF
--- a/ckanext/datajson/templates/organization/read.html
+++ b/ckanext/datajson/templates/organization/read.html
@@ -12,7 +12,7 @@
         <form id="formRedacted" action="{{c.group_dict.id + '/redacted.json' }}"></form>
         <form id="formDraft" action="{{c.group_dict.id + '/draft.json' }}"></form>
 
-        <script type="text/javascript" src="/base/vendor/jquery.min.js"></script>
+        <script type="text/javascript" src="/base/vendor/jquery.js"></script>
         <script type="text/javascript">
             $(document).ready(function () {
                 $('#btnUnredacted').click(function () {


### PR DESCRIPTION
CKAN removed references to the [min-versions of jquery](https://github.com/ckan/ckan/commit/ff5cf01677d14ba33ce2388a8ed2d3231947b1ba) so javascript stuff was breaking.  This just updates the filenames.