### PR TITLE
split string for python2.7 and 3

### DIFF
--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -80,7 +80,6 @@ class Package2Pod(object):
     @staticmethod
     def export_map_fields(package, json_export_map, redaction_enabled=False):
         import os
-        import string
         import sys
 
         public_access_level = helpers.get_extra(package, 'public_access_level')
@@ -140,7 +139,7 @@ class Package2Pod(object):
                             if helpers.is_redacted(found_element):
                                 dataset[key] = found_element
                             elif split:
-                                dataset[key] = [Package2Pod.filter(x) for x in string.split(found_element, split)]
+                                dataset[key] = [Package2Pod.filter(x) for x in found_element.split(split)]
 
                     else:
                         if array_key:


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/3616

`string.split()` is not available in python 3.

