### PR TITLE
fix inventory_parent_uid

### DIFF
--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -390,7 +390,7 @@ class Wrappers(object):
             import ckan.model as model
 
             parent = model.Package.get(parent_dataset_id)
-            parent_uid = parent.extras.col.target['unique_id'].value
+            parent_uid = parent.extras['unique_id']
             if parent_uid:
                 parent_dataset_id = parent_uid
         return parent_dataset_id


### PR DESCRIPTION
In ckan 2.9 line
```
parent.extras.col.target['unique_id'].value
```
gives error complaining `col` does not have property `target`. Change the way to get `unique_id` that works in both ckan 2.8 and ckan 2.9.