### PR TITLE
validate email

### DIFF
--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -5,7 +5,6 @@ import csv
 import os
 import re
 import rfc3987 as rfc3987_url
-from validate_email import validate_email
 
 # from the iso8601 package, plus ^ and $ on the edges
 ISO8601_REGEX = re.compile(r"^([0-9]{4})(-([0-9]{1,2})(-([0-9]{1,2})"
@@ -150,10 +149,8 @@ def do_validation(doc, errors_array, seen_identifiers):
                 if check_required_string_field(cp, "hasEmail", 9, dataset_name, errs):
                     if not is_redacted(cp.get('hasEmail')):
                         email = cp["hasEmail"].replace('mailto:', '')
-                        if not validate_email(email_address=email,
-                                              check_blacklist=False,
-                                              check_dns=False,
-                                              check_smtp=False):
+                        email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+                        if not re.match(email_regex, email):
                             add_error(errs, 5, "Invalid Required Field Value",
                                       "The email address \"%s\" is not a valid email address." % email,
                                       dataset_name)

--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -1,8 +1,11 @@
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
+import csv
+import os
 import re
 import rfc3987 as rfc3987_url
+from validate_email import validate_email
 
 # from the iso8601 package, plus ^ and $ on the edges
 ISO8601_REGEX = re.compile(r"^([0-9]{4})(-([0-9]{1,2})(-([0-9]{1,2})"
@@ -82,14 +85,7 @@ REDACTED_REGEX = re.compile(
     r'^(\[\[REDACTED).*?(\]\])$'
 )
 
-import lepl.apps.rfc3696
-
-email_validator = lepl.apps.rfc3696.Email()
-
 # load the OMB bureau codes on first load of this module
-import csv
-import os
-
 omb_burueau_codes = set()
 # for row in csv.DictReader(urllib.urlopen("https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv")):
 #    omb_burueau_codes.add(row["Agency Code"] + ":" + row["Bureau Code"])
@@ -154,7 +150,10 @@ def do_validation(doc, errors_array, seen_identifiers):
                 if check_required_string_field(cp, "hasEmail", 9, dataset_name, errs):
                     if not is_redacted(cp.get('hasEmail')):
                         email = cp["hasEmail"].replace('mailto:', '')
-                        if not email_validator(email):
+                        if not validate_email(email_address=email,
+                                              check_blacklist=False,
+                                              check_dns=False,
+                                              check_smtp=False):
                             add_error(errs, 5, "Invalid Required Field Value",
                                       "The email address \"%s\" is not a valid email address." % email,
                                       dataset_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyyaml
-py3-validate-email
 jsonschema==2.4.0
 rfc3987
 future

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml
-lepl
+py3-validate-email
 jsonschema==2.4.0
 rfc3987
 future


### PR DESCRIPTION
Remove outdated `lepl.apps.rfc3696`. It does not work for python 3.8.
~~Replace it with `py3-validate-email`.~~  <-- does not work with ckan2.8/python2.7
Replace it with plain regex.