### PR TITLE
Str encode

### DIFF
--- a/ckanext/datajson/blueprint.py
+++ b/ckanext/datajson/blueprint.py
@@ -325,12 +325,12 @@ def write_zip(data, error=None, errors_json=None, zip_name='data'):
     # Errors in json format
     if errors_json:
         # logger.debug('writing errors.json')
-        zf.writestr('errors.json', json.dumps(errors_json).encode('utf8'))
+        zf.writestr('errors.json', json.dumps(errors_json))
 
     # Write the error log
     if error:
         # logger.debug('writing errorlog.txt')
-        zf.writestr('errorlog.txt', error.encode('utf8').replace("\n", "\r\n"))
+        zf.writestr('errorlog.txt', error.replace("\n", "\r\n"))
 
     zf.close()
     o.seek(0)

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -390,9 +390,8 @@ class Wrappers(object):
             import ckan.model as model
 
             parent = model.Package.get(parent_dataset_id)
-            parent_uid = parent.extras['unique_id']
-            if parent_uid:
-                parent_dataset_id = parent_uid
+            if parent and parent.extras['unique_id']:
+                parent_dataset_id = parent.extras['unique_id']
         return parent_dataset_id
 
     @staticmethod


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/3628

The issue is that `zf.writestr` does not like encoded string. Remove` .encode('utf8')` so we can see the actual error message in the zip file, not a 500 error.

Also handle some obvious issues than will for sure generate error during data.json export.
