### PR TITLE
Feature/harvest optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CKAN_VERSION ?= 2.8
+CKAN_VERSION ?= 2.9
 COMPOSE_FILE ?= docker-compose.yml
 COMPOSE_LEGACY_FILE ?= docker-compose.legacy.yml
 

--- a/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
+++ b/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
@@ -201,6 +201,24 @@ class TestDataJSONHarvester(object):
         assert munge_title_to_name("ORNL") in tags
         assert len(dataset.resources) == 1
 
+    def test_datason_arm_reharvest(self):
+        url = 'http://127.0.0.1:%s/arm' % self.mock_port
+        datasets = self.run_source(url=url)
+        # Mark harvest job as complete
+        # utils.run_harvester()
+        # fake job status before final RUN command.
+        context = {'model': model, 'user': self.user['name'], 'session': model.Session}
+        self.job.status = u'Running'
+        self.job.gather_finished = datetime.utcnow()
+        self.job.save()
+
+        p.toolkit.get_action('harvest_jobs_run')(context, {'source_id': self.source.id})
+
+        # Re-run job to check update logic
+        datasets = self.run_source(url=url)
+        # Assert no datasets were changed
+        assert datasets == []
+
     def test_datason_usda(self):
         url = 'http://127.0.0.1:%s/usda' % self.mock_port
         datasets = self.run_source(url=url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ rfc3987
 future
 
 # ckanext-harvest
--e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest
+-e git+https://github.com/ckan/ckanext-harvest.git@89b1a322acfcdabdf3274d3c47dd95291c9c5427#egg=ckanext-harvest
 ckantoolkit==0.0.3
 pika>=1.1.0
 pyOpenSSL==18.0.0

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,7 @@ function ckan_wrapper () {
 }
 
 # Database is listening, but still unavailable. Just keep trying...
-while ! ckan_wrapper --plugin=ckan db init; do 
+while ! ckan db init; do 
   echo Retrying in 5 seconds...
   sleep 5
 done


### PR DESCRIPTION
This removes `package_show` call, which lowers the load on SOLR during harvesting. Adds a test case to validate the re-harvest case (harvesting with current data sources), but still doesn't cover all use cases.

Also other optimizations/changes to make tests work more normally, including:

- Assuming CKAN2.9 (instead of CKAN2.8)
- Using `ckan` cli
- Pin harvester so that tests will pass