### PR TITLE
Add back lepl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.1',
+    version='0.1.2',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -28,10 +28,11 @@ setup(
     zip_safe=False,
     install_requires=[
         # -*- Extra requirements: -*-
-        'pyyaml',
-        'jsonschema~=2.4.0',
-        'rfc3987',
         'future'
+        'jsonschema~=2.4.0',
+        'lepl',
+        'pyyaml',
+        'rfc3987',
     ],
     setup_requires=['wheel'],
     entry_points="""


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3414
- https://github.com/GSA/catalog.data.gov/pull/493

It seems as if https://github.com/GSA/ckanext-datajson/commit/9b39558352b675454aa24d1979d3f69112839903 accidentally deleted it and https://github.com/GSA/ckanext-datajson/commit/778319a11f430660e1c35cbf586a55ec45046b17 didn't add it back properly