### PR TITLE
draft changes for unique identifier links

### DIFF
--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -275,6 +275,8 @@ class DatasetHarvesterBase(HarvesterBase):
             elif dataset.get('isPartOf'):
                 is_part_of = dataset.get('isPartOf')
                 existing_parent = existing_parents.get(is_part_of, None)
+                # We should NEVER change the data like this as it's being gathered/imported
+                # Why do we need the CKAN ID, isn't the unique identifier good enough?
                 if existing_parent is None:  # maybe the parent is not harvested yet
                     parent_pkg_id = 'IPO:{}'.format(is_part_of)
                 else:
@@ -390,6 +392,10 @@ class DatasetHarvesterBase(HarvesterBase):
 
         return harvest_object.source.id if harvest_object else None
 
+    # Why do we need this? Shouldn't the isPartOf field be validated as
+    # part of the validation step, and not on import?
+    # Can we write some sort of post-harvest check to add errors if items
+    # are harvested without their parent?
     def is_part_of_to_package_id(self, ipo, harvest_object):
         """ Get an identifier from external source using isPartOf
             and returns the parent dataset or raises an ParentNotHarvestedException.

--- a/ckanext/datajson/tests/datajson-samples/unique-identifier-http.data.json
+++ b/ckanext/datajson/tests/datajson-samples/unique-identifier-http.data.json
@@ -1,0 +1,105 @@
+{
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog",
+    "dataset": [
+        {
+            "accessLevel": "public",
+            "bureauCode": [
+                "018:001"
+            ],
+            "license": "https://project-open-data.cio.gov/unknown-license",
+            "identifier": "https://org.gov/datasets/sub-id",
+            "contactPoint": {
+                "hasEmail": "mailto:adc@arm.gov",
+                "fn": "ARM Data Center"
+            },
+            "description": "No description found",
+            "programCode": [
+                "018:001"
+            ],
+            "distribution": [
+                {
+                    "accessURL": "http://www.archive.arm.gov/discovery/#v/results/s/s::ncepgfsbrwpprof",
+                    "format": "cdf"
+                }
+            ],
+            "modified": "2022-11-02 18:48:55.063953",
+            "isPartOf": "https://org.gov/datasets/id",
+            "publisher": {
+                "name": "Atmospheric Radiation Measurement Data Center",
+                "subOrganizationOf": {
+                    "name": "DOE Biological and Environmental Research (BER)",
+                    "subOrganizationOf": {
+                        "name": "DOE Office of Science user facilities",
+                        "subOrganizationOf": {
+                            "name": "U.S. Government"
+                        }
+                    }
+                }
+            },
+            "@type": "dcat:Dataset",
+            "keyword": [
+                "ARM",
+                "ORNL",
+                "ADC",
+                "ARM Data Center",
+                "Climate",
+                "Atmospheric Data",
+                "ncepgfs",
+                "National Centers for Environment Prediction Global Forecast System",
+                "derivmod"
+            ],
+            "title": "SUB NCEP GFS: vertical profiles of met quantities at standard pressures, at Barrow"
+        },
+        {
+            "accessLevel": "public",
+            "bureauCode": [
+                "018:001"
+            ],
+            "license": "https://project-open-data.cio.gov/unknown-license",
+            "identifier": "https://org.gov/datasets/id",
+            "contactPoint": {
+                "hasEmail": "mailto:adc@arm.gov",
+                "fn": "ARM Data Center"
+            },
+            "description": "No description found",
+            "programCode": [
+                "018:001"
+            ],
+            "distribution": [
+                {
+                    "accessURL": "http://www.archive.arm.gov/discovery/#v/results/s/s::ncepgfsbrwpprof",
+                    "format": "cdf"
+                }
+            ],
+            "modified": "2022-11-02 18:48:55.063939",
+            "publisher": {
+                "name": "Atmospheric Radiation Measurement Data Center",
+                "subOrganizationOf": {
+                    "name": "DOE Biological and Environmental Research (BER)",
+                    "subOrganizationOf": {
+                        "name": "DOE Office of Science user facilities",
+                        "subOrganizationOf": {
+                            "name": "U.S. Government"
+                        }
+                    }
+                }
+            },
+            "@type": "dcat:Dataset",
+            "keyword": [
+                "ARM",
+                "ORNL",
+                "ADC",
+                "ARM Data Center",
+                "Climate",
+                "Atmospheric Data",
+                "ncepgfs",
+                "National Centers for Environment Prediction Global Forecast System",
+                "derivmod"
+            ],
+            "title": "NCEP GFS: vertical profiles of met quantities at standard pressures, at Barrow"
+        }
+    ]
+}

--- a/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
+++ b/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
@@ -34,6 +34,7 @@ class TestDataJSONHarvester(object):
         log.info('Starting mock http server')
         cls.mock_port = 8961
         mock_datajson_source.serve(cls.mock_port)
+        cls.source = None
 
     @classmethod
     def setup(cls):
@@ -212,6 +213,14 @@ class TestDataJSONHarvester(object):
         datasets = self.run_source(url=url)
         # Assert no datasets were changed
         assert datasets == []
+    
+    def test_datason_unique_identifier_http(self):
+        url = 'http://127.0.0.1:%s/unique-identifier-http' % self.mock_port
+        # We may need to run the gather manually here, so that we can
+        # force the sub item to be harvested before the parent item
+        # and confirm our current bug is fixed.
+        datasets = self.run_source(url=url)
+        # Verify that the dataset and sub were both harvested
 
     def test_datason_usda(self):
         url = 'http://127.0.0.1:%s/usda' % self.mock_port


### PR DESCRIPTION
Long term fix for https://github.com/GSA/data.gov/issues/4040. Why do we change data on the fly, and check datasets harvested into the system? Why not validate fully and trust the validation?