### PR TITLE
add order_by so that active package wins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # ckanext-harvest
--e git+https://github.com/ckan/ckanext-harvest.git@89b1a322acfcdabdf3274d3c47dd95291c9c5427#egg=ckanext-harvest
-ckantoolkit==0.0.3
-pika>=1.1.0
-pyOpenSSL>=22.0.0
+-e git+https://github.com/ckan/ckanext-harvest.git@2e5ac42f3ba58dd4bcb1e69a783e155828ff4b89#egg=ckanext-harvest
+ckantoolkit>=0.0.7
+pika>=1.1.0,<1.3.0
+enum34; python_version < '3.0'  # Required by pika
 redis
 requests>=2.11.1
+six>=1.12.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.10',
+    version='0.1.11',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/2989.

Adding a `sort_by` and let the active package, if any,  be the last one in the `existing_datasets`.