### PR TITLE
Add documentation from geoplatform

### DIFF
--- a/ckanext/datajson/tests/datajson-samples/README.md
+++ b/ckanext/datajson/tests/datajson-samples/README.md
@@ -6,7 +6,8 @@ You can see this example at [geospatial.data.json](./geospatial.data.json).
 
 The examples adds a new `Dataset Distribution Field` for the link. 
 The requirements are to utilize the `conformsTo` field to specify what metadata flavor is used, 
-so that downstream users (ie Geoplatform) can examine and decide if this metadata is ingestible/usable. 
+so that downstream users (ie Geoplatform) can examine and decide if this metadata is ingestible/usable.
+See geoplatform necessary specifications [here](https://kb.geoplatform.gov/gc-fac-isocsdgmdcat.html#geospatial-metadata-link-example).
 This is easily discoverable and usable by both machines and users.
 
 Best practice also includes the following:

--- a/ckanext/datajson/tests/datajson-samples/geospatial.data.json
+++ b/ckanext/datajson/tests/datajson-samples/geospatial.data.json
@@ -45,70 +45,10 @@
           "@type": "dcat:Distribution",
           "title": "[Anything valid here] Original Metadata",
           "downloadURL": "https://meta.geo.census.gov/data/existing/decennial/GEO/GPMB/TIGERline/TIGER2013/county/tl_2013_us_county.shp.iso.xml",
-          "conformsTo": "http://www.isotc211.org/2005/gmi",
+          "conformsTo": "http://www.isotc211.org/2005/gmd",
           "description": "[Not required] The metadata original format",
           "mediaType": "text/xml",
           "format": "XML"
-        }
-      ]
-    },
-    {
-      "@type": "dcat:Dataset",
-      "title": "ConformsTo ISO Extension Example: Jellyfish movement data - Determining Movement Patterns of Jellyfish", 
-      "description": "This project is to determine horizontal and vertical movement patterns of two jellyfish species in Hood Canal, in relation to environmental variables. It is being conducted by NMFS scientists in collaboration with a NOAA Hollings Scholar; we also are making use of publicly available oceanographic data from the University of Washington. We used acoustic tags and receivers to track jellyfish movement patterns and correlated their movements with oceanographic data. This project will produce peer reviewed manuscripts. The target audience is fisheries and marine resource managers in Puget Sound and along the West Coast. This is a one-time, standalone project without a firm deadline.\nThis data set contains acoustic telemetry data for lions mane and fried egg jellyfish.", 
-      "modified": "2017-06-10T17:31:25.399151",
-      "bureauCode": [
-          "006:48"
-      ],
-      "programCode": [
-          "006:056"
-      ],
-      "keyword": [
-          "acoustic tracking",
-          "diel vertical movement",
-          "fried egg jellyfish",
-          "lion's mane jellyfish",
-          "source or sink"
-      ],
-      "theme": ["geospatial"],
-      "identifier": "gov.noaa.nmfs.inport:17780",
-      "accessLevel": "public",
-      "spatial": "{\"type\": \"Polygon\", \"coordinates\": [[[-123.1304, 47.4051], [-123.1204, 47.4051], [-123.1204, 47.4151], [-123.1304, 47.4151], [-123.1304, 47.4051]]]}",
-      "publisher": {
-        "@type": "org:Organization",
-        "name": "National Oceanic and Atmospheric Administration"
-      }, 
-      "contactPoint": {
-        "@type": "vcard:Contact",
-        "fn": "(); Northwest Fisheries Science Center (Point of Contact, Custodian)",
-        "hasEmail": "mailto:Kelly.Andrews@noaa.gov"
-      }, 
-      "distribution": [
-        {
-          "@type": "dcat:Distribution",
-          "title": "Jellyfish movement data",
-          "accessURL": "https://www.webapps.nwfsc.noaa.gov/apex/parrdata/inventory/datasets/dataset/6244"
-        },
-        {
-          "@type": "dcat:Distribution",
-          "title": "[Anything valid here] Original Metadata",
-          "downloadURL": "https://data.noaa.gov/waf/NOAA/nmfs/nwfsc/iso/xml/17780.xml",
-          "conformsTo": "https://data.noaa.gov/resources/iso19139/schema.xsd",
-          "description": "[Not required] The metadata original format",
-          "mediaType": "text/xml",
-          "format": "XML"
-        },
-        {
-          "@type": "dcat:Distribution", 
-          "title": "Website", 
-          "description": "Website listed for this contact", 
-          "accessURL": "http://www.nwfsc.noaa.gov"
-        }, 
-        {
-          "@type": "dcat:Distribution", 
-          "title": "NOAA Data Management Plan (DMP)", 
-          "description": "NOAA Data Management Plan for this record on InPort.", 
-          "accessURL": "https://inport.nmfs.noaa.gov/inport/item/17780/dmp"
         }
       ]
     },
@@ -156,7 +96,7 @@
           "@type": "dcat:Distribution",
           "title": "[Anything valid here] Original Metadata",
           "downloadURL": "https://data.usgs.gov/metadata/Geologic_Hazards_Science_Center/5ec70f9d82ce476925eddc9e.xml",
-          "conformsTo": "https://www.fgdc.gov/schemas/metadata/fgdc-std-001-1998.xsd",
+          "conformsTo": "http://www.fgdc.gov/schemas/metadata",
           "description": "[Not required] The metadata original format",
           "mediaType": "text/xml",
           "format": "XML"


### PR DESCRIPTION
Update test/examples to reflect geoplatform best practices: https://kb.geoplatform.gov/gc-fac-isocsdgmdcat.html#geospatial-metadata-link-example.
Removed NOAA example, as that isn't something Geoplatform is supporting.

cc @chris-macdermaid