### PR TITLE
added the checking for dataset title and identifier before referring it

### DIFF
--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -242,6 +242,10 @@ class DatasetHarvesterBase(HarvesterBase):
             if not matched_filters:
                 continue
 
+            if 'identifier' not in dataset:
+                self._save_gather_error("The property identifier is required", harvest_job)
+                continue
+
             # Some source contains duplicate identifiers. skip all except the first one
             if dataset['identifier'] in unique_datasets:
                 self._save_gather_error("Duplicate entry ignored for identifier: '%s'." % (dataset['identifier']), harvest_job)
@@ -460,6 +464,11 @@ class DatasetHarvesterBase(HarvesterBase):
             return True
 
         dataset = json.loads(harvest_object.content)
+
+        if 'title' not in dataset:
+            self._save_object_error(f"Identifier {dataset['identifier']}: missing title field", harvest_object, 'Import')
+            return None
+
         # Ensure title is a string for munging/manipulation
         # https://github.com/GSA/data.gov/issues/4172
         dataset['title'] = str(dataset['title'])

--- a/ckanext/datajson/tests/datajson-samples/missing-identifier-title.data.json
+++ b/ckanext/datajson/tests/datajson-samples/missing-identifier-title.data.json
@@ -1,0 +1,108 @@
+{
+  "@type": "dcat:Catalog",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "dataset": [
+    {
+      "accessLevel": "public",
+      "contactPoint": {
+        "hasEmail": "mailto:Alexis.Graves@ocio.usda.gov",
+        "@type": "vcard:Contact",
+        "fn": "Nicole Numbi"
+      },
+      "programCode": [
+        "005:059"
+      ],
+      "description": "Sample dataset. Spatial can be null",
+      "title": "simple test title",
+      "distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "downloadURL": "http://www.dm.usda.gov/foia/docs/Copy%20of%20ECM%20Congressional%20Logs%20FY14.xls",
+          "mediaType": "application/vnd.ms-excel",
+          "title": "Congressional Logs for Fiscal Year 2014"
+        }
+      ],
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "bureauCode": [
+        "005:12"
+      ],
+      "modified": "2014-10-03",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Department of Agriculture"
+      },
+      "spatial": null,
+      "keyword": [
+        "Congressional Logs"
+      ]
+    },
+    {
+      "identifier": "Test-0001",
+      "accessLevel": "public",
+      "contactPoint": {
+        "hasEmail": "mailto:Alexis.Graves@ocio.usda.gov",
+        "@type": "vcard:Contact",
+        "fn": "Nicole Numbi"
+      },
+      "programCode": [
+        "006:059"
+      ],
+      "description": "Sample dataset. Spatial can be null",
+      "title": "simple test title2",
+      "distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "downloadURL": "http://www.dm.usda.gov/foia/docs/Copy%20of%20ECM%20Congressional%20Logs%20FY14.xls",
+          "mediaType": "application/vnd.ms-excel",
+          "title": "Congressional Logs for Fiscal Year 2014"
+        }
+      ],
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "bureauCode": [
+        "005:12"
+      ],
+      "modified": "2015-10-03",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Department of Agriculture"
+      },
+      "spatial": null,
+      "keyword": [
+        "Congressional Logs2"
+      ]
+    },
+    {
+      "identifier": "Test-0002",
+      "accessLevel": "public",
+      "contactPoint": {
+        "hasEmail": "mailto:Alexis.Graves@ocio.usda.gov",
+        "@type": "vcard:Contact",
+        "fn": "Nicole Numbi"
+      },
+      "programCode": [
+        "006:059"
+      ],
+      "description": "Sample dataset. Spatial can be null",
+      "distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "downloadURL": "http://www.dm.usda.gov/foia/docs/Copy%20of%20ECM%20Congressional%20Logs%20FY14.xls",
+          "mediaType": "application/vnd.ms-excel",
+          "title": "Congressional Logs for Fiscal Year 2014"
+        }
+      ],
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "modified": "2015-10-03",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Department of Agriculture"
+      },
+      "spatial": null,
+      "keyword": [
+        "Congressional Logs2"
+      ]
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.12',
+    version='0.1.13',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Related:
[Catalog harvest does not report error when data.json is invalid #3658](https://github.com/GSA/data.gov/issues/3658)
[gather fails on datajson record without an identifier#4080](https://github.com/GSA/data.gov/issues/4080)

Included checks for the dataset's `title` and `identifier `before referring to them.