### PR TITLE
Fix inventory download error

### DIFF
--- a/ckanext/datajson/helpers.py
+++ b/ckanext/datajson/helpers.py
@@ -186,6 +186,21 @@ def get_extra(package, key, default=None):
     return packageExtraCache.get(package, key, default)
 
 
+def get_additional_formats():
+    import os
+    format_file_path = os.path.join(os.path.dirname(__file__), 'resources', 'additional_resource_formats.json')
+    resource_formats = {}
+    with open(format_file_path, encoding='utf-8') as format_file:
+        file_resource_formats = json.loads(format_file.read())
+        for format_line in file_resource_formats:
+            if format_line[0] == '_comment':
+                continue
+            line = [format_line[2], format_line[0], format_line[1]]
+            resource_formats[format_line[].lower()] = line
+
+    return resource_formats
+
+
 class PackageExtraCache(object):
     def __init__(self):
         self.pid = None

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -473,6 +473,7 @@ class Wrappers(object):
         if not value:
             return value
         formats = h.resource_formats()
+        formats.update(helpers.get_additional_formats())
         format_clean = value.lower()
         if format_clean in formats:
             mime_type = formats[format_clean][0]

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -476,6 +476,7 @@ class Wrappers(object):
         format_clean = value.lower()
         if format_clean in formats:
             mime_type = formats[format_clean][0]
+            mime_type = mime_type if mime_type else 'application/octet-stream'
         else:
             mime_type = value
         msg = value + ' ... BECOMES ... ' + mime_type

--- a/ckanext/datajson/resources/additional_resource_formats.json
+++ b/ckanext/datajson/resources/additional_resource_formats.json
@@ -1,0 +1,8 @@
+[
+  ["_comment",
+   "JSON field order as follows:",
+   ["Format", "Description", "Mimetype"],
+   " * This is a mimetype list additional to CKAN list at ckan/ckan/config/resource_formats.json. "
+  ],
+  ["GEOTIFF", "Geographic Tagged Image File Format", "image/tiff"]
+]


### PR DESCRIPTION
## Related issues:
[Inventory data.json export error#4237](https://github.com/GSA/data.gov/issues/4237)
[mimetype 'Geotiff' missing from the ckan resource_formats #4252](https://github.com/GSA/data.gov/issues/4252)

## Changes
Added code to replace None with general mimetype to avoid concatenation type error
Added additional resource formats file to convert `geotiff` to` image/tiff`