### PR TITLE
truncate error message if too big

### DIFF
--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -385,7 +385,11 @@ class DatasetHarvesterBase(HarvesterBase):
 
     # make ValidationError readable.
     def _validate_readable_msg(self, e):
-        msg = e.message.replace("u'", "'")
+        msg = e.message
+        # limit the message size to be 150 characters
+        if len(msg) > 150:
+            msg = msg[:100] + " ...[truncated]... " + msg[-50:]
+
         elem = ""
         try:
             if e.schema_path[0] == 'properties':

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.14',
+    version='0.1.15',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4236.

Truncating individual error message to 150 chars, with which hopefully the whole `object_error_message` does not go beyond solrStr limit `32766`. 