### PR TITLE
Revert "give a default """

### DIFF
--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -142,7 +142,7 @@ class Package2Pod(object):
                     method = getattr(Wrappers, wrapper)
                     if method:
                         Wrappers.current_field_map = field_map
-                        dataset[key] = method(dataset.get(key, ""))
+                        dataset[key] = method(dataset.get(key))
 
             # CKAN doesn't like empty values on harvest, let's get rid of them
             # Remove entries where value is None, "", or empty list []


### PR DESCRIPTION
This reverts commit 97cf7f1c9189d29505a0a48ab93a5e0eae08fa12.

Not sure about the impact of this revert, but the original issue was fixed by [the other PR](https://github.com/GSA/ckanext-datajson/pull/140). This change was unnecessary. 