### PR TITLE
CKAN 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   lint-test:
     name: Lint + Test
-    uses: gsa/data.gov/.github/workflows/ckan-test.yml@main
+    uses: gsa/data.gov/.github/workflows/ckan-test.yml@ckan-210
     with:
       ext_name: datajson
       plugins: datajson harvest datajson_validator datajson_harvest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   lint-test:
     name: Lint + Test
-    uses: gsa/data.gov/.github/workflows/ckan-test.yml@ckan-210
+    uses: gsa/data.gov/.github/workflows/ckan-test.yml@main
     with:
       ext_name: datajson
       plugins: datajson harvest datajson_validator datajson_harvest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CKAN_VERSION=2.9
+ARG CKAN_VERSION=2.10
 FROM openknowledge/ckan-dev:${CKAN_VERSION}
 
 RUN apk add tzdata

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CKAN_VERSION ?= 2.9.5
+CKAN_VERSION ?= 2.10
 COMPOSE_FILE ?= docker-compose.yml
 
 build: ## Build the docker containers

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -8,7 +8,6 @@ from . import blueprint
 class DataJsonPlugin(p.SingletonPlugin):
     p.implements(p.interfaces.IConfigurer)
     p.implements(p.ITemplateHelpers)
-    p.implements(p.interfaces.IRoutes, inherit=True)
     p.implements(p.IBlueprint)
 
     def update_config(self, config):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pycodestyle
 pytest
 pytest-ckan
 pytest-cov
+mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,4 +44,4 @@ services:
   redis:
     image: redis
   solr:
-    image: ckan/ckan-solr-dev:${SERVICES_VERSION}
+    image: ckan/ckan-solr-dev:2.9

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.17',
+    version='0.1.18',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.18',
+    version='0.1.19',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4209

Changes:
- There are no breaking changes between CKAN 2.9 and CKAN 2.10 with datajson.
- This PR is more of a historical checkpoint.
- We were not using `IRoutes` since `pylons`, so it was breaking 2.10.  But we were not utilizing that code, so it is still compatible with 2.9