### PR TITLE
str validator

### DIFF
--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -6,7 +6,7 @@ from ckan.logic.validators import name_validator
 import ckan.lib.dictization.model_dictize as model_dictize
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.navl.dictization_functions import Invalid, DataError
-from ckan.lib.navl.validators import ignore_empty
+from ckan.lib.navl.validators import ignore_empty, unicode_only
 from ckan.lib.search import rebuild
 
 from ckanext.harvest.model import HarvestObject, HarvestObjectError, HarvestObjectExtra
@@ -103,7 +103,7 @@ class DatasetHarvesterBase(HarvesterBase):
 
     def extra_schema(self):
         return {
-            'validator_schema': [ignore_empty, str, validate_schema],
+            'validator_schema': [ignore_empty, unicode_only, validate_schema],
         }
 
     def gather_stage(self, harvest_job):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.19',
+    version='0.1.20',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix an error when saving a datajson harvest source with non-federal validation schema, as seen in the [slack message](https://gsa-tts.slack.com/archives/C2N85536E/p1689705336293719).


```
ERR File "/home/vcap/deps/1/src/ckanext-harvest/ckanext/harvest/logic/validators.py", line 180, in harvest_source_extra_validator
ERR extra_data, extra_errors = validate(data.get(key, {}), extra_schema)
ERR File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/navl/dictization_functions.py", line 305, in validate
ERR flat_data, errors = _validate(flattened, schema, validators_context)
ERR File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/navl/dictization_functions.py", line 356, in _validate
ERR convert(converter, key, converted_data, errors, context)
ERR File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/navl/dictization_functions.py", line 248, in convert
ERR raise TypeError(
ERR TypeError: str cannot be used as validator because it is not a user-defined function
```