### PR TITLE
Geojson error handling

### DIFF
--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -795,7 +795,12 @@ class DatasetHarvesterBase(HarvesterBase):
             pkg = existing_pkg
 
             log.warn('updating package %s (%s) from %s' % (pkg["name"], pkg["id"], harvest_object.source.url))
-            pkg = get_action('package_update')(self.context(), pkg)
+            try:
+                pkg = get_action('package_update')(self.context(), pkg)
+            except ValidationError as e:
+                log.error('Failed to update package %s: %s' % (pkg["name"], str(e)))
+                self._save_object_error('Error updating package: %s' % (e), harvest_object, 'Import')
+                return None
         else:
             # It doesn't exist yet. Create a new one.
             pkg['name'] = self.make_package_name(dataset_processed["title"], harvest_object.guid)

--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -814,6 +814,10 @@ class DatasetHarvesterBase(HarvesterBase):
                 pkg['name'] = self.make_package_name(dataset_processed["title"], harvest_object.guid)
                 pkg = get_action('package_create')(self.context(), pkg)
                 log.warn('created package %s (%s) from %s' % (pkg["name"], pkg["id"], harvest_object.source.url))
+            except ValidationError as e:
+                log.error('Failed to create package %s: %s' % (pkg["name"], str(e)))
+                self._save_object_error('Error creating package: %s' % (e), harvest_object, 'Import')
+                return None
             except Exception as e:
                 log.error('Failed to create package %s from %s\n\t%s\n\t%s' % (pkg["name"],
                                                                                harvest_object.source.url,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.21',
+    version='0.1.22',
     description="CKAN extension to generate /data.json",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR will address [the Geojson error](https://github.com/GSA/data.gov/issues/4223#issuecomment-1749478485) that crashes fetch process.  Instead of crashing, now it reports the following error and resume fetch process.

```
ERROR [ckanext.datajson.datajson] Failed to update ****: None - {'spatial': ['Error: Wrong GeoJSON object']}
DEBUG [ckanext.harvest.model] Error updating package: None - {'spatial': ['Error: Wrong GeoJSON object']}
```

The error also shows up in the job report instead of being silently ignored.
 
![image](https://github.com/GSA/ckanext-datajson/assets/1392461/4a9385fa-6f28-46e8-8af4-0d5485f522e2)
