### PR TITLE
Max resource

### DIFF
--- a/ckanext/datajson/parse_datajson.py
+++ b/ckanext/datajson/parse_datajson.py
@@ -1,6 +1,6 @@
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.navl.dictization_functions import DataError
-from ckan.plugins.toolkit import config
+from ckan.plugins.toolkit import asint, config
 
 import re
 
@@ -110,7 +110,8 @@ def parse_datajson_entry(datajson, package, defaults, schema_version):
                 }
                 distribution.append(d)
 
-    max_resource_count = config.get('ckanext.datajson.max_resource_count')
+    # max_resource_count is unlimited if not set or set to 0
+    max_resource_count = asint(config.get('ckanext.datajson.max_resource_count', 0))
     if max_resource_count and len(distribution) > max_resource_count:
         error_message = (f'Too many resources. Maximum allowed is {max_resource_count}. '
                          f'Actual size is {len(distribution)}.')

--- a/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
+++ b/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
@@ -613,7 +613,7 @@ class TestDataJSONHarvester(object):
                 parent = model.Package.get(parent_package_id)
                 assert parent.title == 'Employee Relations Roundtables 2'
 
-    @pytest.mark.ckan_config('ckanext.datajson.max_resource_count', 10)
+    @pytest.mark.ckan_config('ckanext.datajson.max_resource_count', '10')
     def test_too_many_resources(self):
         url = 'http://127.0.0.1:%s/many-resources' % self.mock_port
         self.run_source(url=url)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datajson',
-    version='0.1.26',
+    version='0.1.27',
     description='CKAN extension to generate /data.json',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
compare int to int, not str

This fix error:
```
TypeError: '>' not supported between instances of 'int' and 'str'
```