### PR TITLE
additional fields are added into extra and serialized

### DIFF
--- a/ckanext/datajson/datajson.py
+++ b/ckanext/datajson/datajson.py
@@ -754,7 +754,7 @@ class DatasetHarvesterBase(HarvesterBase):
             for key in unmapped:
                 value = dataset_processed.get(key, "")
                 if value is not None:
-                    extras.append({"key": key, "value": value})
+                    extras.append({"key": key, "value": self.serialize_list_dict(value)})
 
         # if theme is geospatial/Geospatial, we tag it in metadata_type.
         themes = self.find_extra(pkg, "theme")
@@ -848,6 +848,14 @@ class DatasetHarvesterBase(HarvesterBase):
         rebuild(pkg['id'])
 
         return True
+
+    def serialize_list_dict(self, data):
+        # we need to serialize dict since CKAN/solr has issues with dict as extras value.
+        # list too, it can have a dict in it.
+        if isinstance(data, dict) or isinstance(data, list):
+            return json.dumps(data)
+        else:
+            return data
 
     def make_upstream_content_hash(self, datasetdict, harvest_source,
                                    catalog_extras, schema_version='1.0',

--- a/ckanext/datajson/tests/datajson-samples/usda.gov.data.json
+++ b/ckanext/datajson/tests/datajson-samples/usda.gov.data.json
@@ -6,6 +6,10 @@
   "dataset": [
     {
       "identifier": "USDA-DM-002",
+      "additionalField": "some Value",
+      "additionalFieldDict": {"a": 3},
+      "additionalFieldList": [1,2,"a"],
+      "additionalFieldListWDict": [1,2,{"a": 3}],
       "accessLevel": "public",
       "contactPoint": {
         "hasEmail": "mailto:Alexis.Graves@ocio.usda.gov",

--- a/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
+++ b/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
@@ -220,6 +220,13 @@ class TestDataJSONHarvester(object):
         tags = [tag.name for tag in dataset.get_tags()]
         assert len(dataset.resources) == 1
         assert munge_title_to_name("Congressional Logs") in tags
+        assert dataset.extras.get('publisher') == 'Department of Agriculture'
+        # addional fields not in the schema should be added as extras
+        # and list and dict should be json encoded
+        assert dataset.extras.get('additionalField') == "some Value"
+        assert json.loads(dataset.extras.get('additionalFieldDict')) == {"a": 3}
+        assert json.loads(dataset.extras.get('additionalFieldList')) == [1,2,"a"]
+        assert json.loads(dataset.extras.get('additionalFieldListWDict')) == [1,2,{"a": 3}]
 
     def test_source_returning_http_error(self):
         url = 'http://127.0.0.1:%s/404' % self.mock_port

--- a/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
+++ b/ckanext/datajson/tests/test_datajson_ckan_all_harvester.py
@@ -225,8 +225,8 @@ class TestDataJSONHarvester(object):
         # and list and dict should be json encoded
         assert dataset.extras.get('additionalField') == "some Value"
         assert json.loads(dataset.extras.get('additionalFieldDict')) == {"a": 3}
-        assert json.loads(dataset.extras.get('additionalFieldList')) == [1,2,"a"]
-        assert json.loads(dataset.extras.get('additionalFieldListWDict')) == [1,2,{"a": 3}]
+        assert json.loads(dataset.extras.get('additionalFieldList')) == [1, 2, "a"]
+        assert json.loads(dataset.extras.get('additionalFieldListWDict')) == [1, 2, {"a": 3}]
 
     def test_source_returning_http_error(self):
         url = 'http://127.0.0.1:%s/404' % self.mock_port


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/5124

Values put into CKAN extra fields are JSON serialized since we found out harvest fetch process crashes when there is a `dict` type of data in the value. 
